### PR TITLE
Convert to SoftwareSerial

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Provides:
 ```C
 #include "VEDirect.h"
 
-VEDirect my_bmv(Serial3);
+VEDirect my_bmv;
 my_int32 = my_bmv.read(VE_SOC);	
 
 // VE_SOC, VE_VOLTAGE, VE_CURRENT, VE_POWER, VE_ALARM

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Provides:
  - Defaults set to read Volts, Power, Current, State of Charge (SOC), Alarm
  - Easily extendible by adding labels for any other stats and settings of interest
  - A diagnostic "full dump" of everything coming from the device  
+ 
+ This branch implements SoftwareSerial primarily for ESP8266 boards that need their native USB port for debug purposes.
 
 ### Usage:
 ```C

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Provides:
 ```C
 #include "VEDirect.h"
 
-VEDirect my_bmv;
+// Serial pins
+#define rxPin D7
+#define txPin D8
+
+VEDirect my_bmv(rxPin, txPin);
 my_int32 = my_bmv.read(VE_SOC);	
 
 // VE_SOC, VE_VOLTAGE, VE_CURRENT, VE_POWER, VE_ALARM

--- a/examples/ReadVEDirect/ReadVEDirect.ino
+++ b/examples/ReadVEDirect/ReadVEDirect.ino
@@ -15,13 +15,17 @@
 #include "Arduino.h"
 #include "VEDirect.h"
 
+// Serial pins
+#define rxPin D7
+#define txPin D8
+
 // 32 bit ints to collect the data from the device
 int32_t VE_soc, VE_power, VE_voltage, VE_current;
 // Boolean to collect an ON/OFF value
 uint8_t VE_alarm;
 
 // VEDirect instantiated with relevant serial object
-VEDirect myve;
+VEDirect myve(rxPin, txPin);
 
 void setup() {
 	Serial.begin(19200);		// Adjust as needed - DEBUG serial port

--- a/examples/ReadVEDirect/ReadVEDirect.ino
+++ b/examples/ReadVEDirect/ReadVEDirect.ino
@@ -8,6 +8,8 @@
 
  File: ReadVEDirect.ino / ReadVEDirect.cpp
  - Provides example use of the VEDirect library
+
+ 2020.04.10 - convert to SoftwareSerial
 ******************************************************************/
 
 #include "Arduino.h"
@@ -19,10 +21,10 @@ int32_t VE_soc, VE_power, VE_voltage, VE_current;
 uint8_t VE_alarm;
 
 // VEDirect instantiated with relevant serial object
-VEDirect myve(Serial3);
+VEDirect myve;
 
 void setup() {
-	Serial.begin(9600);		// Adjust as needed
+	Serial.begin(19200);		// Adjust as needed - DEBUG serial port
 }
 
 void loop() {

--- a/src/VEDirect.cpp
+++ b/src/VEDirect.cpp
@@ -15,12 +15,9 @@
 
 #include "VEDirect.h"
 
-// Serial variables
-#define rxPin D7
-#define txPin D8 
-
 VEDirect::VEDirect():
-	VESerial (*new SoftwareSerial(rxPin, txPin))
+VEDirect::VEDirect(byte rxPin, byte txPin):
+	VESerial(*new SoftwareSerial(rxPin, txPin))
 	// Initialise the serial port that the
 	// VE.Direct device is connected to and
 	// store it for later use.

--- a/src/VEDirect.cpp
+++ b/src/VEDirect.cpp
@@ -10,12 +10,17 @@
  - Implementation
  Updates:
  - 2019-07-14 See VEDirect.h
+ - 2020-04-10 Converted to SoftwareSerial, added checks for null pointers for ESP8266
 ******************************************************************/
 
 #include "VEDirect.h"
 
-VEDirect::VEDirect(HardwareSerial& port):
-	VESerial(port)
+// Serial variables
+#define rxPin D7
+#define txPin D8 
+
+VEDirect::VEDirect():
+	VESerial (*new SoftwareSerial(rxPin, txPin))
 	// Initialise the serial port that the
 	// VE.Direct device is connected to and
 	// store it for later use.
@@ -28,7 +33,7 @@ VEDirect::~VEDirect() {
 
 uint8_t VEDirect::begin() {
 	// Check connection the serial port
-	VESerial.begin(19200);
+	VESerial.begin(VED_BAUD_RATE);
 	if (VESerial) {
 		delay(500);
 		if(VESerial.available()) {
@@ -85,26 +90,30 @@ int32_t VEDirect::read(uint8_t target) {
 			}
 
 			label = strtok(line, "\t");
-			if (strcmp_P(label, ved_labels[target]) == 0) {
-				value_str = strtok(0, "\t");
-				if (value_str[0] == 'O') { 		//ON OFF type
-					if (value_str[1] == 'N') {
-						ret = 1;	// ON
-						break;
-					} else {
-						ret = 0;	// OFF
-						break;
-					}
-				} else {
-					sscanf(value_str, "%ld", &ret);
-					break;
+			if (label) {
+				if (strcmp_P(label, ved_labels[target]) == 0) {
+					value_str = strtok(0, "\t");
+					if (value_str) {
+						if (value_str[0] == 'O') { 		//ON OFF type
+							if (value_str[1] == 'N') {
+								ret = 1;	// ON
+								break;
+							} else {
+								ret = 0;	// OFF
+								break;
+							}
+						} else {
+							sscanf(value_str, "%ld", &ret);
+							break;
+						}
+					}	
+				} else {			// Line not of interest
+					lines--;
+					loops = VED_MAX_READ_LOOPS;
+					line[0] = '\0';
+					idx = 0;
 				}
-			} else {			// Line not of interest
-				lines--;
-				loops = VED_MAX_READ_LOOPS;
-				line[0] = '\0';
-				idx = 0;
-			}
+			}	
 		}
 	}
 	return ret;

--- a/src/VEDirect.cpp
+++ b/src/VEDirect.cpp
@@ -11,11 +11,11 @@
  Updates:
  - 2019-07-14 See VEDirect.h
  - 2020-04-10 Converted to SoftwareSerial, added checks for null pointers for ESP8266
+ - 2020-08-31 Removed errant constructor
 ******************************************************************/
 
 #include "VEDirect.h"
 
-VEDirect::VEDirect():
 VEDirect::VEDirect(byte rxPin, byte txPin):
 	VESerial(*new SoftwareSerial(rxPin, txPin))
 	// Initialise the serial port that the

--- a/src/VEDirect.h
+++ b/src/VEDirect.h
@@ -55,7 +55,7 @@ const char ved_labels[VE_LAST_LABEL][VED_MAX_LEBEL_SIZE] PROGMEM = {
 
 class VEDirect {
 public:
-	VEDirect();
+	VEDirect(byte rxPin, byte txPin);
 	virtual ~VEDirect();
 	uint8_t begin();
 	int32_t read(uint8_t target);

--- a/src/VEDirect.h
+++ b/src/VEDirect.h
@@ -15,12 +15,15 @@
   	  - Target labels extendible with enum and PROGMEM strings
   	  - Retired copy_raw_to_serial0() code - use VE_DUMP on read
   	  - Added some tunable parameters see #defines
+ - 2020-04-10:
+	  - Convert to SoftwareSerial so ESP8266 can use native usb serial for debug
 ******************************************************************/
 
 #ifndef VEDIRECT_H_
 #define VEDIRECT_H_
 
 #include <Arduino.h>
+#include <SoftwareSerial.h>
 
 // Tunable parameters - defaults tested on mega2560 R3
 #define VED_LINE_SIZE 30		 // Seems to be plenty. VE.Direct protocol could change
@@ -52,13 +55,13 @@ const char ved_labels[VE_LAST_LABEL][VED_MAX_LEBEL_SIZE] PROGMEM = {
 
 class VEDirect {
 public:
-	VEDirect(HardwareSerial& port);
+	VEDirect();
 	virtual ~VEDirect();
 	uint8_t begin();
 	int32_t read(uint8_t target);
 	void copy_raw_to_serial0(); // kept for backwards compatibility
 private:
-	HardwareSerial& VESerial;
+	SoftwareSerial& VESerial;
 };
 
 #endif /* VEDIRECT_H_ */


### PR DESCRIPTION
Convert library to SoftwareSerial so ESP8266 can use native USB port for debug.  Using D7/D8 for rec/xmit.  Also added NULL pointer checks that were previously mentioned by others.  Assuming some may want to stay with HardwareSerial, so maybe this branch can just sit here for whoever wants it.  Modified .cpp, .h, and example files.  Tested on ESP8266 NodeMCU 1.0 (ESP-12E).